### PR TITLE
Feature/rails 4 upgrade

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,5 @@ gem "rails_warden"
 group :test, :development do
   gem "rspec-rails", '~> 2.14'
   gem "factory_girl_rails"
+  gem 'test-unit'
 end

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ def session_record_params
 end
 ```
 
-#### Session Subject
+#### Subject
 
 ```
 private

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Concepts
 Demonstration
 -------------
 To get started a *very* basic sample app is provided at spec/dummy.
- 
-    bundler exec unicorn 
+
+    bundler exec unicorn
 
 to try it out.
 
@@ -29,7 +29,7 @@ Clone the repository to your local disk and in your Gemfile add:
 
 		gem 'federated_rails', '0.1.0', :path => "yourpath/federated_rails"
 
-Alternatively use the bundler git syntax. 
+Alternatively use the bundler git syntax.
 
 Once this is done execute the supplied generator
 
@@ -40,10 +40,10 @@ Subject should be the name of your subject class you can change this to say User
 You'll then need to add
 
     acts_as_federated
-    
+
 to your application_controller.rb. This will authenticate all controller requests except supplied by the engine. To disable use:
 
-    skip_before_filter :ensure_valid_subject 
+    skip_before_filter :ensure_valid_subject
 
 Configuration
 -------------
@@ -71,6 +71,34 @@ security_manager is available to your controllers and views to provide details a
 
 provisioning_manager allows you to modify what happens when a Subject is created or how it is updated when they subsequently visit your application.
 
+Integrating Strong Parameters with your Controllers
+---------------------------------
+Since the `attr_accessor` method has been extracted out of Rails 4.0+ we recommend that you use strong parameters in your controllers when interacting with the `subject` and `session_record` models.
+
+These snippets should be a useful starting point, but you may need to adapt this for your use case.
+
+
+#### Session Record
+
+```
+private
+
+def session_record_params
+  params.require(:subject).permit(:credential, :remote_host, :user_agent)
+end
+```
+
+#### Session Subject
+
+```
+private
+
+def subject_params
+  params.require(:subject).permit(:administrator, :subject)
+end
+
+```
+
 Contributing
 ------------
 All contributions welcome. Simply fork and send a pull request when you have something new or log an issue.
@@ -82,4 +110,3 @@ Requests for additional information to go along with this documentation are also
 Credits
 -------
 FederatedRails was written by Bradley Beddoes on behalf of the Australian Access Federation.
-

--- a/lib/generators/federated_rails/templates/session_record.rb.erb
+++ b/lib/generators/federated_rails/templates/session_record.rb.erb
@@ -2,5 +2,4 @@ class SessionRecord < ActiveRecord::Base
 	belongs_to :<%= model.downcase %>
 
 	validates_presence_of :credential, :remote_host, :user_agent
-  attr_accessible :credential, :remote_host, :user_agent
 end

--- a/lib/generators/federated_rails/templates/subject.rb.erb
+++ b/lib/generators/federated_rails/templates/subject.rb.erb
@@ -4,8 +4,6 @@ class <%= model %> < ActiveRecord::Base
 	validates_presence_of :principal
 	validates_uniqueness_of :principal
 	validates_associated :session_records
-  
-  attr_accessible :administrator, :subject
 
 	def to_s
 		"<%= model.downcase %> [#{self.id}, #{self.principal}]"

--- a/spec/dummy/config/environments/development.rb
+++ b/spec/dummy/config/environments/development.rb
@@ -10,7 +10,6 @@ Dummy::Application.configure do
 
   # Show full error reports and disable caching
   config.consider_all_requests_local       = true
-  config.action_view.debug_rjs             = true
   config.action_controller.perform_caching = false
 
   # Don't care if the mailer can't send
@@ -22,4 +21,3 @@ Dummy::Application.configure do
   # Only use best-standards-support built into browsers
   config.action_dispatch.best_standards_support = :builtin
 end
-

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -8,11 +9,11 @@
 # from scratch. The latter is a flawed and unsustainable approach (the more migrations
 # you'll amass, the slower it'll run and the greater likelihood for issues).
 #
-# It's strongly recommended to check this file into your version control system.
+# It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 5016) do
+ActiveRecord::Schema.define(version: 5016) do
 
-  create_table "session_records", :force => true do |t|
+  create_table "session_records", force: true do |t|
     t.string   "credential"
     t.string   "remote_host"
     t.string   "user_agent"
@@ -21,9 +22,9 @@ ActiveRecord::Schema.define(:version => 5016) do
     t.datetime "updated_at"
   end
 
-  create_table "subjects", :force => true do |t|
+  create_table "subjects", force: true do |t|
     t.string   "principal"
-    t.boolean  "enabled",    :default => false
+    t.boolean  "enabled",    default: false
     t.datetime "created_at"
     t.datetime "updated_at"
   end


### PR DESCRIPTION
This gem had some outstanding issues with use on Rails 4.0+ which have been resolved in this PR.

Changes made are:

- Added `test-unit` gem to Gemfile as this was not being installed by bundler despite being a required dependency.
- Removed rjs_debug option from development.rb in the dummy app
- Removed attr_accessible as this is deprecated and will not work in Rails 4 without the `protected_attributes` gem.
- Added documentation on how to integrate strong parameters for `subject` and `session_record` models into Rails controllers for end-user developers.

I have tested this gem locally again rails 4.0.2 on ruby 2.3.0.

